### PR TITLE
Add 'photo' field to updateUserProfileSchema validation schema

### DIFF
--- a/src/validation/users.js
+++ b/src/validation/users.js
@@ -31,5 +31,5 @@ export const updateUserProfileSchema = Joi.object({
   activityLevel: Joi.number().integer().min(1).max(5).optional(),
   gender: Joi.string().valid('male', 'female').optional(),
   dailyRequirement: Joi.number().integer().min(200).max(5000),
-  // photo: Joi.string().uri().optional(),
+  photo: Joi.string().uri().allow(''),
 });


### PR DESCRIPTION
- Updated updateUserProfileSchema to include optional 'photo' field.
- Allowed empty string for 'photo' field to handle cases where no image is provided.